### PR TITLE
Sidekick fix from jaPRO/videoP

### DIFF
--- a/game/bg_pmove.cpp
+++ b/game/bg_pmove.cpp
@@ -2218,7 +2218,12 @@ static qboolean PM_CheckJump( void ) {
 				vector3	idealNormal = { 0 }, wallNormal = { 0 };
 				trace_t	trace;
 				qboolean doTrace = qfalse;
-				int contents = MASK_PLAYERSOLID;
+                                int contents; //MASK_PLAYERSOLID;
+
+                                if (GetCInfo( CINFO_FLIPKICK ) > 0)
+                                        contents = MASK_PLAYERSOLID;//MASK_PLAYERSOLID;
+                                else
+                                        contents = MASK_SOLID;
 
 				VectorSet( &mins, pm->mins.x, pm->mins.y, 0 );
 				VectorSet( &maxs, pm->maxs.x, pm->maxs.y, 24 );


### PR DESCRIPTION
Typically this is from jaPRO / videoP so when japp_flipKick is set to 0 it stops the side kick animation.

Thought I should contribute something because I am using JA++ for server side. Even though its not my fix but helping somehow.