### PR TITLE
Fix bgAllAnims being assigned a value before initialized.

### DIFF
--- a/cgame/cg_main.cpp
+++ b/cgame/cg_main.cpp
@@ -1701,6 +1701,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
     const char *s;
 
     // clear out globals
+    BG_InitAnimsets();
     memset(cg_entities, 0, sizeof(cg_entities));
 
     cgs.~cgs_t();
@@ -1737,7 +1738,6 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
         trap->Print("Not logging security events to disk.\n");
 
     // load some permanent stuff
-    BG_InitAnimsets();
     BG_VehicleLoadParms();
     CG_InitJetpackGhoul2();
     CG_PmoveClientPointerUpdate();


### PR DESCRIPTION
Fixes #452
This PR just moves the call to `BG_InitAnimsets` further up in the Init code so bgAllAnims gets initialized before it gets used.