### PR TITLE
Fix formatting of asm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           lua package.lua
           7z a -tzip -y japp-windows-${{ matrix.arch }}-${{ matrix.build_type }}.zip *.pk3
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.build_type == 'Release' }}
         with:
           name: japp-windows-${{ matrix.arch }}-${{ matrix.build_type }}
@@ -132,7 +132,7 @@ jobs:
           ./package.lua
           tar -czvf japp-linux-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz *.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.build_type == 'Release' }}
         with:
           name: japp-linux-${{ matrix.arch }}-${{ matrix.build_type }}
@@ -169,7 +169,7 @@ jobs:
           ./package.lua
           tar -czvf japp-macos-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz *.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.build_type == 'Release' }}
         with:
           name: japp-macos-${{ matrix.arch }}-${{ matrix.build_type }}
@@ -186,7 +186,7 @@ jobs:
           submodules: recursive
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create binary archives
         run: |
@@ -240,7 +240,7 @@ jobs:
           submodules: recursive
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create archive
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
 
   macos:
     name: macOS ${{ matrix.arch }} ${{ matrix.build_type }}
-    runs-on: macos-12
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:

--- a/JAPP/jp_crash.cpp
+++ b/JAPP/jp_crash.cpp
@@ -986,29 +986,34 @@ static LONG WINAPI UnhandledExceptionHandler_Failsafe(struct _EXCEPTION_POINTERS
         // Alright, we got a VERY serious issue here..
         // In this state the exception handler itself will run outta stack too
         // So we'll just use a nice hack here to roll up esp by 16k
+
+        // clang-format off
 #if defined(_MSC_VER)
         qasm2(mov eax, EI)
 #elif defined(__GNUC__)
         __asm__("mov %0, esp" : "=m"(StackBackupStart) :);
 #endif
-            qasm2(mov esi, esp)
+        qasm2(mov esi, esp)
 #if defined(_MSC_VER)
-                qasm2(mov edi, offset StackBackup)
+        qasm2(mov edi, offset StackBackup)
 #elif defined(__GNUC__)
-            __asm__("mov edi, offset %0"
-                    :
-                    : "m"(StackBackup));
+        __asm__("mov edi, offset %0"
+                :
+                : "m"(StackBackup));
 #endif
-                    qasm2(mov ecx, 0x6000) qasm1(rep stosd) qasm2(add esp, 0x18000) qasm1(push eax)
+        qasm2(mov ecx, 0x6000)
+        qasm1(rep stosd)
+        qasm2(add esp, 0x18000)
+        qasm1(push eax)
 #if defined(_MSC_VER)
-                        qasm1(call UnhandledExceptionHandler)
+        qasm1(call UnhandledExceptionHandler)
 #elif defined(__GNUC__)
-            __asm__("call %0"
-                    :
-                    : "r"(UnhandledExceptionHandler));
+        __asm__("call %0" : : "r"(UnhandledExceptionHandler));
 #endif
-            // qasm1( jmp skip )
-            qasm1(ret)
+        // qasm1( jmp skip )
+        qasm1(ret)
+
+        // clang-format on
     }
     StackBackupStart = 0;
     return UnhandledExceptionHandler(EI);

--- a/qcommon/q_math.cpp
+++ b/qcommon/q_math.cpp
@@ -145,21 +145,21 @@ void CrossProductA( float *v1, float *v2, float *cross ) {
 		__asm fmul  dword ptr[ecx + 8]
 		__asm fld   dword ptr[eax + 8]
 		__asm fmul  dword ptr[ecx + 4]
-		__asm fsubp st( 1 ), st
+		__asm fsubp st(1), st
 	__asm fstp  dword ptr[edx]
 
 		__asm fld   dword ptr[eax + 8]
 		__asm fmul  dword ptr[ecx]
 		__asm fld   dword ptr[eax]
 		__asm fmul  dword ptr[ecx + 8]
-		__asm fsubp st( 1 ), st
+		__asm fsubp st(1), st
 	__asm fstp  dword ptr[edx + 4]
 
 		__asm fld   dword ptr[eax]
 		__asm fmul  dword ptr[ecx + 4]
 		__asm fld   dword ptr[eax + 4]
 		__asm fmul  dword ptr[ecx]
-		__asm fsubp st( 1 ), st
+		__asm fsubp st(1), st
 	__asm fstp  dword ptr[edx + 8]
 #endif
 }
@@ -633,23 +633,33 @@ int BoxOnPlaneSide(vector3 *emins, vector3 *emaxs, struct cplane_s *p) {
 #endif // _MSC_VER
 
 Q_NAKED int BoxOnPlaneSide(vector3 *emins, vector3 *emaxs, struct cplane_s *p) {
+    // clang-format off
     qnakedstart(BOPS)
 
-        static int Q_USED bops_initialized;
+    static int Q_USED bops_initialized;
     static int Q_USED Ljmptab[8];
 
 #if defined(_MSC_VER)
-    qasm1(push ebx) qasm2(cmp bops_initialized, 1) qasm1(je initialized) qasm2(mov bops_initialized, 1)
+    qasm1(push ebx)
+    qasm2(cmp bops_initialized, 1)
+    qasm1(je initialized)
+    qasm2(mov bops_initialized, 1)
 #elif defined(__GNUC__)
     __asm__("push %ebx");
     __asm__("cmp %0, 1\n" : : "r"(bops_initialized));
-    qasm1(je initialized) __asm__("mov %0, 1\n" : "=r"(bops_initialized) :);
+    qasm1(je initialized)
+    __asm__("mov %0, 1\n" : "=r"(bops_initialized) :);
 #endif
 
 #if defined(_MSC_VER)
-        qasm2(mov Ljmptab[0 * 4], offset Lcase0) qasm2(mov Ljmptab[1 * 4], offset Lcase1) qasm2(mov Ljmptab[2 * 4], offset Lcase2)
-            qasm2(mov Ljmptab[3 * 4], offset Lcase3) qasm2(mov Ljmptab[4 * 4], offset Lcase4) qasm2(mov Ljmptab[5 * 4], offset Lcase5) qasm2(
-                mov Ljmptab[6 * 4], offset Lcase6) qasm2(mov Ljmptab[7 * 4], offset Lcase7)
+    qasm2(mov Ljmptab[0 * 4], offset Lcase0)
+    qasm2(mov Ljmptab[1 * 4], offset Lcase1)
+    qasm2(mov Ljmptab[2 * 4], offset Lcase2)
+    qasm2(mov Ljmptab[3 * 4], offset Lcase3)
+    qasm2(mov Ljmptab[4 * 4], offset Lcase4)
+    qasm2(mov Ljmptab[5 * 4], offset Lcase5)
+    qasm2(mov Ljmptab[6 * 4], offset Lcase6)
+    qasm2(mov Ljmptab[7 * 4], offset Lcase7)
 #elif defined(__GNUC__)
     __asm__("mov %0, offset Lcase0\n" : "=m"(Ljmptab[0]) :);
     __asm__("mov %0, offset Lcase1\n" : "=m"(Ljmptab[1]) :);
@@ -661,164 +671,231 @@ Q_NAKED int BoxOnPlaneSide(vector3 *emins, vector3 *emaxs, struct cplane_s *p) {
     __asm__("mov %0, offset Lcase7\n" : "=m"(Ljmptab[7]) :);
 #endif
 
-                qasmL(initialized:) qasm2(mov edx, dword ptr[4 + 12 + esp]) qasm2(mov ecx, dword ptr[4 + 4 + esp]) qasm2(xor eax, eax) qasm2(
-                    mov ebx, dword ptr[4 + 8 + esp]) qasm2(mov al, byte ptr[17 + edx]) qasm2(cmp al,
-                                                                                             8) qasm1(jge Lerror) qasm1(fld dword ptr[0 + edx]) qasm1(fld st(0))
+    qasmL(initialized:)
+    qasm2(mov edx, dword ptr[4 + 12 + esp])
+    qasm2(mov ecx, dword ptr[4 + 4 + esp])
+    qasm2(xor eax, eax)
+    qasm2(mov ebx, dword ptr[4 + 8 + esp])
+    qasm2(mov al, byte ptr[17 + edx])
+    qasm2(cmp al, 8)
+    qasm1(jge Lerror)
+    qasm1(fld dword ptr[0 + edx])
+    qasm1(fld st(0))
 #if defined(_MSC_VER)
-                    qasm1(jmp dword ptr[Ljmptab + eax * 4])
+    qasm1(jmp dword ptr[Ljmptab + eax * 4])
 #elif defined(__GNUC__)
-        __asm__("jmp dword ptr[%0 + eax * 4]\n"
-                :
-                : "r"(Ljmptab));
+    __asm__("jmp dword ptr[%0 + eax * 4]\n" : : "r"(Ljmptab));
 #endif
 
-                        qasmL(Lcase0:) qasm1(fmul dword ptr[ebx]) qasm1(fld dword ptr[0 + 4 + edx]) qasm1(fxch st(2)) qasm1(fmul dword ptr[ecx])
-                            qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[4 + ebx]) qasm1(fld dword ptr[0 + 8 + edx]) qasm1(fxch st(2)) qasm1(
-                                fmul dword ptr[4 + ecx]) qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[8 + ebx]) qasm1(fxch st(5))
-                                qasm2(faddp st(3), st(0)) qasm1(fmul dword ptr[8 + ecx]) qasm1(fxch st(1)) qasm2(faddp st(3), st(0)) qasm1(fxch st(3)) qasm2(
-                                    faddp st(2), st(0)) qasm1(jmp LSetSides)
+    qasmL(Lcase0:)
+    qasm1(fmul dword ptr[ebx] )
+    qasm1(fld dword ptr[0 + 4 + edx] )
+    qasm1(fxch st(2) )
+    qasm1(fmul dword ptr[ecx] )
+    qasm1(fxch st(2) )
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ebx] )
+    qasm1(fld dword ptr[0 + 8 + edx] )
+    qasm1(fxch st(2) )
+    qasm1(fmul dword ptr[4 + ecx] )
+    qasm1(fxch st(2) )
+    qasm1(fld st(0) )
+    qasm1(fmul dword ptr[8 + ebx] )
+    qasm1(fxch st(5) )
+    qasm2(faddp st(3), st(0) )
+    qasm1(fmul dword ptr[8 + ecx] )
+    qasm1(fxch st(1) )
+    qasm2(faddp st(3), st(0) )
+    qasm1(fxch st(3) )
+    qasm2(faddp st(2), st(0) )
+    qasm1(jmp LSetSides )
 
-                                    qasmL(Lcase1:) qasm1(fmul dword ptr[ecx]) qasm1(fld dword ptr[0 + 4 + edx]) qasm1(fxch st(2)) qasm1(fmul dword ptr[ebx])
-                                        qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[4 + ebx]) qasm1(fld dword ptr[0 + 8 + edx]) qasm1(fxch st(2))
-                                            qasm1(fmul dword ptr[4 + ecx]) qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[8 + ebx]) qasm1(fxch st(5))
-                                                qasm2(faddp st(3), st(0)) qasm1(fmul dword ptr[8 + ecx]) qasm1(fxch st(1)) qasm2(faddp st(3), st(0)) qasm1(
-                                                    fxch st(3)) qasm2(faddp st(2), st(0)) qasm1(jmp LSetSides)
+    qasmL(Lcase1:)
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
+    qasm1(jmp LSetSides)
 
-                                                    qasmL(Lcase2:) qasm1(fmul dword ptr[ebx]) qasm1(fld dword ptr[0 + 4 + edx]) qasm1(fxch st(2))
-                                                        qasm1(fmul dword ptr[ecx]) qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[4 + ecx]) qasm1(
-                                                            fld dword ptr[0 + 8 + edx]) qasm1(fxch st(2)) qasm1(fmul dword ptr[4 + ebx])
-                                                            qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[8 + ebx]) qasm1(fxch st(5)) qasm2(
-                                                                faddp st(3), st(0)) qasm1(fmul dword ptr[8 + ecx]) qasm1(fxch st(1)) qasm2(faddp st(3), st(0))
-                                                                qasm1(fxch st(3)) qasm2(
-                                                                    faddp st(2), st(0)) qasm1(jmp LSetSides)
+    qasmL(Lcase2:)
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
+    qasm1(jmp LSetSides)
 
-                                                                    qasmL(Lcase3:) qasm1(fmul dword ptr[ecx]) qasm1(fld dword ptr[0 + 4 + edx])
-                                                                        qasm1(fxch st(2)) qasm1(fmul dword ptr[ebx]) qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(
-                                                                            fmul dword ptr[4 + ecx]) qasm1(fld dword ptr[0 + 8 + edx]) qasm1(fxch st(2))
-                                                                            qasm1(fmul dword ptr[4 + ebx]) qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(
-                                                                                fmul dword ptr[8 + ebx]) qasm1(fxch st(5)) qasm2(faddp st(3), st(0))
-                                                                                qasm1(fmul dword ptr[8 + ecx]) qasm1(fxch st(1)) qasm2(
-                                                                                    faddp st(3),
-                                                                                    st(0)) qasm1(fxch st(3)) qasm2(faddp st(2),
-                                                                                                                   st(0)) qasm1(jmp LSetSides)
+    qasmL(Lcase3:)
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
+    qasm1(jmp LSetSides)
 
-                                                                                    qasmL(Lcase4:) qasm1(fmul dword ptr[ebx]) qasm1(
-                                                                                        fld dword ptr[0 + 4 + edx]) qasm1(fxch st(2)) qasm1(fmul dword ptr[ecx])
-                                                                                        qasm1(fxch st(2)) qasm1(fld st(0)) qasm1(fmul dword ptr[4 + ebx]) qasm1(
-                                                                                            fld dword ptr[0 + 8 + edx]) qasm1(fxch st(2))
-                                                                                            qasm1(fmul dword ptr[4 + ecx]) qasm1(fxch st(2)) qasm1(fld st(
-                                                                                                0)) qasm1(fmul dword ptr[8 + ecx]) qasm1(fxch st(5))
-                                                                                                qasm2(faddp st(3), st(0)) qasm1(fmul dword ptr[8 + ebx]) qasm1(
-                                                                                                    fxch st(1)) qasm2(faddp st(3), st(0)) qasm1(fxch st(3))
-                                                                                                    qasm2(faddp st(2), st(0)) qasm1(jmp LSetSides)
+    qasmL(Lcase4:)
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
+    qasm1(jmp LSetSides)
 
-                                                                                                        qasmL(Lcase5:) qasm1(fmul dword ptr[ecx]) qasm1(
-                                                                                                            fld dword ptr[0 + 4 + edx]) qasm1(fxch st(2))
-                                                                                                            qasm1(fmul dword ptr[ebx]) qasm1(fxch st(2)) qasm1(
-                                                                                                                fld st(0)) qasm1(fmul dword ptr[4 + ebx])
-                                                                                                                qasm1(fld dword ptr[0 + 8 + edx]) qasm1(fxch st(2)) qasm1(
-                                                                                                                    fmul dword ptr
-                                                                                                                        [4 +
-                                                                                                                         ecx]) qasm1(fxch st(2)) qasm1(fld st(0))
-                                                                                                                    qasm1(fmul dword ptr[8 + ecx]) qasm1(
-                                                                                                                        fxch st(5)) qasm2(faddp st(3), st(0))
-                                                                                                                        qasm1(fmul dword ptr[8 + ebx]) qasm1(
-                                                                                                                            fxch
-                                                                                                                                st(1)) qasm2(faddp st(3), st(0))
-                                                                                                                            qasm1(fxch st(3)) qasm2(
-                                                                                                                                faddp st(2),
-                                                                                                                                st(0)) qasm1(jmp LSetSides)
+    qasmL(Lcase5:)
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
+    qasm1(jmp LSetSides)
 
-                                                                                                                                qasmL(Lcase6:) qasm1(fmul dword ptr[ebx]) qasm1(
-                                                                                                                                    fld dword
-                                                                                                                                        ptr[0 + 4 + edx])
-                                                                                                                                    qasm1(fxch st(2)) qasm1(
-                                                                                                                                        fmul dword ptr
-                                                                                                                                            [ecx]) qasm1(fxch st(2))
-                                                                                                                                        qasm1(fld st(0)) qasm1(
-                                                                                                                                            fmul dword
-                                                                                                                                                ptr[4 + ecx])
-                                                                                                                                            qasm1(
-                                                                                                                                                fld dword
-                                                                                                                                                    ptr[0 + 8 +
-                                                                                                                                                        edx])
-                                                                                                                                                qasm1(fxch st(2)) qasm1(
-                                                                                                                                                    fmul dword
-                                                                                                                                                        ptr[4 +
-                                                                                                                                                            ebx])
-                                                                                                                                                    qasm1(fxch st(2)) qasm1(
-                                                                                                                                                        fld st(0))
-                                                                                                                                                        qasm1(
-                                                                                                                                                            fmul dword ptr
-                                                                                                                                                                [8 +
-                                                                                                                                                                 ecx])
-                                                                                                                                                            qasm1(
-                                                                                                                                                                fxch
-                                                                                                                                                                    st(5))
-                                                                                                                                                                qasm2(
-                                                                                                                                                                    faddp
-                                                                                                                                                                        st(3),
-                                                                                                                                                                    st(0))
-                                                                                                                                                                    qasm1(fmul dword ptr[8 + ebx])
-                                                                                                                                                                        qasm1(fxch st(1))
-                                                                                                                                                                            qasm2(faddp st(3), st(0))
-                                                                                                                                                                                qasm1(fxch st(3))
-                                                                                                                                                                                    qasm2(faddp st(2), st(0))
-                                                                                                                                                                                        qasm1(jmp LSetSides)
+    qasmL(Lcase6:)
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
+    qasm1(jmp LSetSides)
 
-                                                                                                                                                                                            qasmL(
-                                                                                                                                                                                                Lcase7:
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                        qasm1(fmul dword ptr[ecx]) qasm1(fld dword ptr[0 + 4 + edx]) qasm1(fxch
-                                                                                                                                                                                                                                                                               st(
-                                                                                                                                                                                                                                                                                   2)) qasm1(fmul dword ptr[ebx]) qasm1(fxch
-                                                                                                                                                                                                                                                                                                                            st(
-                                                                                                                                                                                                                                                                                                                                2)) qasm1(fld
-                                                                                                                                                                                                                                                                                                                                              st(0)) qasm1(fmul dword ptr[4 + ecx]) qasm1(fld dword ptr[0 + 8 + edx]) qasm1(fxch
-                                                                                                                                                                                                                                                                                                                                                                                                                                st(2)) qasm1(fmul dword ptr[4 + ebx]) qasm1(fxch
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                st(
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    2)) qasm1(fld
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  st(
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      0)) qasm1(fmul
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    dword
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ptr
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            [8 + ecx]) qasm1(fxch
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 st(
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     5)) qasm2(faddp st(3),
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               st(
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   0)) qasm1(fmul dword ptr[8 + ebx]) qasm1(fxch
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                st(
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    1)) qasm2(faddp st(3), st(0)) qasm1(fxch
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            st(3)) qasm2(faddp st(2), st(0))
+    qasmL(Lcase7:)
+    qasm1(fmul dword ptr[ecx])
+    qasm1(fld dword ptr[0 + 4 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[4 + ecx])
+    qasm1(fld dword ptr[0 + 8 + edx])
+    qasm1(fxch st(2))
+    qasm1(fmul dword ptr[4 + ebx])
+    qasm1(fxch st(2))
+    qasm1(fld st(0))
+    qasm1(fmul dword ptr[8 + ecx])
+    qasm1(fxch st(5))
+    qasm2(faddp st(3), st(0))
+    qasm1(fmul dword ptr[8 + ebx])
+    qasm1(fxch st(1))
+    qasm2(faddp st(3), st(0))
+    qasm1(fxch st(3))
+    qasm2(faddp st(2), st(0))
 
-                                                                                                                                                                                                            qasmL(
-                                                                                                                                                                                                                LSetSides:
-                                                                                                                                                                                                                    ) qasm2(faddp st(2), st(0)) qasm1(fcomp
-                                                                                                                                                                                                                                                          dword
-                                                                                                                                                                                                                                                              ptr
-                                                                                                                                                                                                                                                                  [12 + edx]) qasm2(xor ecx, ecx) qasm1(fnstsw ax) qasm1(fcomp dword ptr[12 +
-                                                                                                                                                                                                                                                                                                                                         edx]) qasm2(and ah, 1) qasm2(xor ah, 1) qasm2(add cl, ah) qasm1(fnstsw ax) qasm2(and ah,
-                                                                                                                                                                                                                                                                                                                                                                                                                          1)
-                                                                                                                                                                                                                        qasm2(add ah, ah) qasm2(add cl, ah)
+    qasmL(LSetSides:)
+    qasm2(faddp st(2), st(0))
+    qasm1(fcomp dword ptr[12 + edx])
+    qasm2(xor ecx, ecx)
+    qasm1(fnstsw ax)
+    qasm1(fcomp dword ptr[12 + edx])
+    qasm2(and ah, 1)
+    qasm2(xor ah, 1)
+    qasm2(add cl, ah)
+    qasm1(fnstsw ax)
+    qasm2(and ah, 1)
+    qasm2(add ah, ah)
+    qasm2(add cl, ah)
 #if defined(_MSC_VER)
-                                                                                                                                                                                                                            qasm1(
-                                                                                                                                                                                                                                pop ebx)
+    qasm1(pop ebx)
 #elif defined(__GNUC__)
-                                                                                                                                                                                                        __asm__(
-                                                                                                                                                                                                            "pop %ebx");
+    __asm__("pop %ebx");
 #endif
-                                                                                                                                                                                                                                qasm2(
-                                                                                                                                                                                                                                    mov eax,
-                                                                                                                                                                                                                                    ecx)
-                                                                                                                                                                                                                                    qasm1(
-                                                                                                                                                                                                                                        ret)
+    qasm2(mov eax, ecx)
+    qasm1(ret)
 
-                                                                                                                                                                                                                                        qasmL(
-                                                                                                                                                                                                                                            Lerror
-:) qasm1(int 3)
+    qasmL(Lerror:)
+    qasm1(int 3)
 
-                                                                                                                                                                                                                                            qnakedend(
-                                                                                                                                                                                                                                                BOPS)
+    qnakedend(BOPS)
+    // clang-format on
 }
 #if defined(_MSC_VER)
 #pragma warning(pop)


### PR DESCRIPTION
Fixed `UnhandledExceptionHandler_Failsafe` and `BoxOnPlaneSide` asm formatting. They got changed in the large formatting pass. I added `clang-format` to the asm to prevent the formatter from changing it back.